### PR TITLE
HuntDomainService 수정 & Test Code 작성

### DIFF
--- a/src/main/java/com/ohgiraffers/metaRPG/domain/service/HuntDomainService.java
+++ b/src/main/java/com/ohgiraffers/metaRPG/domain/service/HuntDomainService.java
@@ -30,7 +30,7 @@ public class HuntDomainService {
 
     // 현재 hp 백분율로 환산
     public int hpCalc(int hp, int maxhp) {
-        int hpPercent = (hp / maxhp) * 100;
+        int hpPercent = (int)((hp / (double) maxhp) * 100);
         return hpPercent;
     }
 

--- a/src/test/java/com/ohgiraffers/metaRPG/domain/service/HuntDomainServiceTest.java
+++ b/src/test/java/com/ohgiraffers/metaRPG/domain/service/HuntDomainServiceTest.java
@@ -1,0 +1,73 @@
+package com.ohgiraffers.metaRPG.domain.service;
+
+import com.ohgiraffers.metaRPG.ContextConfiguration;
+import com.ohgiraffers.metaRPG.domain.entity.MonsterEntity;
+import com.ohgiraffers.metaRPG.domain.entity.UserEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringJUnitConfig(classes = {ContextConfiguration.class})
+public class HuntDomainServiceTest {
+    @Autowired
+    private HuntDomainService huntDomainService;
+    @Test
+    public void setCreateHuntDomainService(){
+        assertNotNull(huntDomainService);
+    }
+    @Test
+    @DisplayName("유저가 기본 공격으로 몬스터를 공격했을 경우, 몬스터의 나머지 체력 확인")
+    public void testAttack(){
+        MonsterEntity monster = new MonsterEntity(1, "빨간 달팽이", 20, 5, 5, 15);
+        UserEntity user = new UserEntity(1, "유저1", 100, 10, 1, 0, 0, 0);
+        boolean flag = true;
+        int restMonsterHp = huntDomainService.attack(flag, monster, user);
+        assertEquals(10, restMonsterHp);
+    }
+
+    @Test
+    @DisplayName("몬스터가 유저를 공격할 경우, 유저의 나머지 체력 확인")
+    public void testDefence(){
+        MonsterEntity monster = new MonsterEntity(1, "빨간 달팽이", 20, 5, 5, 15);
+        UserEntity user = new UserEntity(1, "유저1", 100, 10, 1, 0, 0, 0);
+        boolean flag = false;
+        int restUserHp = huntDomainService.attack(flag, monster, user);
+        assertEquals(95, restUserHp);
+    }
+
+    @Test
+    @DisplayName("2번 피격당한 유저의 현재 HP를 퍼센트로 변환하여 값 Check")
+    public void testHpCalc(){
+        MonsterEntity monster = new MonsterEntity(1, "빨간 달팽이", 20, 5, 5, 15);
+        UserEntity user = new UserEntity(1, "유저1", 100, 10, 1, 0, 0, 0);
+        boolean flag = false;
+        int userMaxHp = 100;
+        int userCurHp = huntDomainService.attack(flag, monster, user);
+        user.setHp(userCurHp);
+        userCurHp = huntDomainService.attack(flag, monster, user);
+        int hpPer = huntDomainService.hpCalc(userCurHp, userMaxHp);
+        assertEquals(90, hpPer);
+    }
+
+    @Test
+    @DisplayName("경험치 받는 메소드 Test")
+    public void testGainEXP(){
+        MonsterEntity monster = new MonsterEntity(1, "빨간 달팽이", 20, 5, 5, 15);
+        boolean flag = true;
+        int exp = huntDomainService.gainEXP(flag, monster);
+        assertEquals(5, exp);
+    }
+
+    @Test
+    @DisplayName("사냥 실패시 돈 적립 메소드 Test")
+    public void testGainMoney(){
+        MonsterEntity monster = new MonsterEntity(1, "빨간 달팽이", 20, 5, 5, 15);
+        boolean flag = false;
+        int money = huntDomainService.gainEXP(flag, monster);
+        assertEquals(0, money);
+    }
+}


### PR DESCRIPTION
# 무슨 이유로 코드를 변경했는지

---
* hpCalc 메소드 변경
* int형으로 나눠서 퍼센트 값이 제대로 반환되지 않았음. 명시적 형변환이 필요하여 코드를 수정함.
---

# 관련 스크린샷
<img width="341" alt="image" src="https://github.com/MetaAir2023/MetaRPG/assets/48685874/2e34165a-8c07-42d5-8aef-931eaffa3157">

---

# 테스트 계획 또는 완료 사항
- [x] 유저가 기본 공격으로 몬스터를 공격했을 경우, 몬스터의 나머지 체력 확인 (value 10 check)
- [x] 몬스터가 유저를 공격할 경우, 유저의 나머지 체력 확인 (value 95 check)
- [x] 2번 피격당한 유저의 현재 HP를 퍼센트로 변환하여 값 Check (value 90 check)
- [x] 경험치 받는 메소드 Test (value 5 check)
- [x] 사냥 실패시 돈 적립 메소드 Test (value 0 check)

---
* 테스트 관련 사항을 입력한다.
* 빨간 달팽이 (몬스터) : 시퀸스 1/hp 20/공격력 5/경험치 5/돈 15
* 유저 : 시퀸스 1/이름 유저1/hp 100/기본 공격력 10/레벨 1/소지금 0/아이템 시퀸스 0/아이템 강화 수치 0

---
# 테스트 관련 스크린샷
<img width="923" alt="image" src="https://github.com/MetaAir2023/MetaRPG/assets/48685874/bd8b8062-b1d5-43e1-8947-9dd8348599e2">
